### PR TITLE
Fixed batch republishing bug

### DIFF
--- a/src/Service/QueueService.php
+++ b/src/Service/QueueService.php
@@ -127,7 +127,7 @@ class QueueService
         return $this->save($this->entityFactory->createQueue($queueable));
     }
 
-    public function flush(QueueEntityInterface $entity): QueueEntityInterface
+    public function flush(QueueEntityInterface $entity = null): QueueEntityInterface
     {
         $this->repository->flush($entity);
 


### PR DESCRIPTION
**Сохранено старое поведение.**
Если сущностей меньше, чем batch size при первом получении данных, то они перепоставляются, и работа команды заканчивается (имитировал старое поведение `do while`).
При втором и последующих получениях данных, если сущностей меньше, чем batch size, то они не будут перепоставляться, и работа команды завершится.

**Суть проблемы.**
Если перепоставить нужно было больше, чем `batch size * 2`, то при первой итерации транзакция коммитилась. На второй итерации действия производились уже без транзакции, после чего команда падала при попытке закоммитить транзакцию, которой как-бы уже нет. Это также ограничивало количество обрабатываемых сущностей до `batch size * 2`.