### PR TITLE
Fixed bug with float multiplier at the GeometricProgressionStrategy

### DIFF
--- a/src/Strategy/Delay/GeometricProgressionStrategy.php
+++ b/src/Strategy/Delay/GeometricProgressionStrategy.php
@@ -22,7 +22,7 @@ class GeometricProgressionStrategy implements DelayStrategyInterface
 
     public function generateInterval(int $iteration): DateInterval
     {
-        $newIntervalSec = $this->startInterval * ($this->multiplier ** ($iteration - 1));
+        $newIntervalSec = (int) ceil($this->startInterval * ($this->multiplier ** ($iteration - 1)));
 
         return new DateInterval('PT' . $newIntervalSec . 'S');
     }

--- a/tests/unit/Strategy/Delay/GeometricProgressionStrategyTest.php
+++ b/tests/unit/Strategy/Delay/GeometricProgressionStrategyTest.php
@@ -33,6 +33,7 @@ class GeometricProgressionStrategyTest extends Unit
             [4, 1, 2, 3],
             [4, 2, 2, 2],
             [480, 60, 2, 4],
+            'float multiplier' => [938, 60, 2.5, 4],
         ];
     }
 }


### PR DESCRIPTION
Problem with float multiplier
```DateInterval::__construct(): Unknown or bad format (PT26.666666666667S)```