### PR TITLE
Add workflow and first ci file, add editorconfig, change Makefile, re…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches:
+    tags:
+  pull_request:
+
+
+jobs:
+    build:
+      runs-on: ${{ matrix.os }}
+      strategy:
+        fail-fast: false
+        matrix:
+          php: [7.1, 7.2, 7.3, 7.4]
+          os: [ubuntu-18.04]
+      name: PHP v${{ matrix.php }} Test ${{ matrix.env }} on ${{ matrix.os }}
+
+      steps:
+      - uses: actions/checkout@v1
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@1.7.4
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, mbstring, pdo
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer --prefer-dist install
+
+      - name: Run tests
+        run: make test-unit
+
+      - name: Run cs-fixer
+        run: make php-cs-fix-diff
+        # Remove after executing command make php-cs-fix and commit changed files
+        continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,8 @@ php-cs-check:
 php-cs-fix:
 	$(WORKING_DIR)/vendor/bin/php-cs-fixer fix
 
+php-cs-fix-diff:
+	$(WORKING_DIR)/vendor/bin/php-cs-fixer fix --dry-run --diff
+
 test-unit:
 	./vendor/bin/codecept run unit


### PR DESCRIPTION
- Added ci file for supporting Github Actions 
- Added `.editorconfig`
- Add step with php-cs-fixer and use with flag `continue-on-error: true` (See [docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)). I suggest if result of command `php-cs-fixer fix` will be commited (25 files now) 